### PR TITLE
Project Routes Integration

### DIFF
--- a/server/prisma/migrations/20210325225834_unique_project_name/migration.sql
+++ b/server/prisma/migrations/20210325225834_unique_project_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - The migration will add a unique constraint covering the columns `[name]` on the table `project`. If there are existing duplicate values, the migration will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "project.name_unique" ON "project"("name");

--- a/server/prisma/migrations/20210325232803_revert_unique_name/migration.sql
+++ b/server/prisma/migrations/20210325232803_revert_unique_name/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "project.name_unique";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -129,7 +129,7 @@ model Notification {
 
 model Project {
   id          Int          @id @default(autoincrement())
-  name        String       @unique
+  name        String
   description String
   devpostUrl  String?
   githubUrl   String

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -129,7 +129,7 @@ model Notification {
 
 model Project {
   id          Int          @id @default(autoincrement())
-  name        String
+  name        String       @unique
   description String
   devpostUrl  String?
   githubUrl   String

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -22,12 +22,14 @@ app.use(compression());
 
 import { isAuthenticated } from "./auth/auth";
 import { authRoutes } from "./routes/auth";
+import { projectRoutes } from "./routes/project";
 
 app.get("/status", (req, res) => {
   res.status(200).send("Success");
 });
 
 app.use("/auth", authRoutes);
+app.use("/projects", isAuthenticated, projectRoutes);
 
 app.use(isAuthenticated, express.static(path.join(__dirname, "../../client/build")));
 app.get("*", isAuthenticated, (req, res) => {

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -37,6 +37,22 @@ projectRoutes.route("/").post(async (req, res) => {
   }
 });
 
+projectRoutes.route("/action/move").post(async (req, res) => {
+  try {
+    const { ids, ...updates } = req.body;
+    ids.forEach(async (id: number) => {
+      await prisma.project.update({
+        where: { id },
+        data: updates
+      });
+    });
+    res.status(200).send("Projects moved successfully!");
+  } catch (err) {
+    console.log(`[ERROR] ${err.message}`);
+    res.status(500).send({ error: true, message: err.message });
+  }
+});
+
 projectRoutes.route("/:id").patch(async (req, res) => {
   try {
     const updated = await prisma.project.update({

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -1,53 +1,52 @@
-import { Request, Response } from "express";
-import { Project } from ".prisma/client";
+import express from "express";
 
 import { asyncHandler } from "../utils/asyncHandler";
 import { prisma } from "../common";
-import express from "express";
 
 export const projectRoutes = express.Router();
 
 projectRoutes.route("/").get(
-  asyncHandler(async (req: Request | any, res: Response) => {
+  asyncHandler(async (req: any, res) => {
     // note: query params default to strings (e.g. 1 → '1'),
     // thus numeric fields must be converted to numbers in
     // order for prisma's queries to function as expected
     Object.keys(req.query).forEach(key => {
-      if (["expo", "round", "table"].includes(key))
+      if (["expo", "round", "table"].includes(key)) {
         req.query[key] = parseInt(req.query[key]);
+      }
     });
-    const matches: Project[] = await prisma.project.findMany({
-      where: req.query
+    const matches = await prisma.project.findMany({
+      where: req.query,
     });
-    res.status(200).send(matches);
+    res.status(200).json(matches);
   })
 );
 
 projectRoutes.route("/").post(
-  asyncHandler(async (req: Request, res: Response) => {
-    const created: Project = await prisma.project.create({
-      data: req.body
+  asyncHandler(async (req, res) => {
+    const created = await prisma.project.create({
+      data: req.body,
     });
     res.status(201).json(created);
   })
 );
 
-projectRoutes.route("/action/move").post(
-  asyncHandler(async (req: Request, res: Response) => {
+projectRoutes.route("/batch/update").post(
+  asyncHandler(async (req, res) => {
     const { ids, ...updates } = req.body;
-    const batchPayload: object = await prisma.project.updateMany({
-      where: { id: { in: ids }},
-      data: updates
+    const batchPayload = await prisma.project.updateMany({
+      where: { id: { in: ids } },
+      data: updates,
     });
     res.status(200).json(batchPayload);
   })
 );
 
 projectRoutes.route("/:id").patch(
-  asyncHandler(async (req: Request, res: Response) => {
-    const updated: Project = await prisma.project.update({
+  asyncHandler(async (req, res) => {
+    const updated = await prisma.project.update({
       where: { id: parseInt(req.params.id) },
-      data: req.body
+      data: req.body,
     });
     res.status(200).json(updated);
   })

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -4,9 +4,15 @@ import express from "express";
 export const projectRoutes = express.Router();
 const prisma = new PrismaClient();
 
-projectRoutes.route("/find").get(async (req, res) => {
+projectRoutes.route("/").get(async (req, res) => {
   try {
-    const projects = await prisma.project.findMany({ where: req.body.query });
+    // todo: find better way of retrieving numeric fields
+    ["id", "expo", "round", "table"].forEach(key => {
+      if (req.query.hasOwnProperty(key))
+        // @ts-ignore
+        req.query[key] = parseInt(req.query[key]);
+    });
+    const projects = await prisma.project.findMany({ where: req.query });
     res.status(200).send(projects);
   } catch (err) {
     console.log(`[ERROR] ${err.message}`);
@@ -14,14 +20,14 @@ projectRoutes.route("/find").get(async (req, res) => {
   }
 });
 
-projectRoutes.route("/create").post(async (req, res) => {
+projectRoutes.route("/").post(async (req, res) => {
   try {
     // todo: find better way of retreiving required fields
     const valid = ["name", "description", "githubUrl"]
-      .every(field => req.body.data.hasOwnProperty(field));
+      .every(field => req.body.hasOwnProperty(field));
     if (valid) {
-      const project = await prisma.project.create({ data: req.body.data });
-      res.status(200).send(project);
+      const created = await prisma.project.create({ data: req.body });
+      res.status(201).send(created);
     } else {
       res.status(400).send("Missing 'name', 'description', or 'githubUrl' fields.");
     }
@@ -31,13 +37,13 @@ projectRoutes.route("/create").post(async (req, res) => {
   }
 });
 
-projectRoutes.route("/update").post(async (req, res) => {
+projectRoutes.route("/:id").patch(async (req, res) => {
   try {
-    const count = await prisma.project.updateMany({
-      where: req.body.query,
-      data: req.body.update
+    const updated = await prisma.project.update({
+      where: { id: parseInt(req.params.id) },
+      data: req.body
     });
-    res.status(200).send(count);
+    res.status(200).send(updated);
   } catch (err) {
     console.log(`[ERROR] ${err.message}`);
     res.status(500).send({ error: true, message: err.message });

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -1,0 +1,45 @@
+import { PrismaClient } from "@prisma/client";
+import express from "express";
+
+export const projectRoutes = express.Router();
+const prisma = new PrismaClient();
+
+projectRoutes.route("/find").get(async (req, res) => {
+  try {
+    const projects = await prisma.project.findMany({ where: req.body.query });
+    res.status(200).send(projects);
+  } catch (err) {
+    console.log(`[ERROR] ${err.message}`);
+    res.status(500).send({ error: true, message: err.message });
+  }
+});
+
+projectRoutes.route("/create").post(async (req, res) => {
+  try {
+    // todo: find better way of retreiving required fields
+    const valid = ["name", "description", "githubUrl"]
+      .every(field => req.body.data.hasOwnProperty(field));
+    if (valid) {
+      const project = await prisma.project.create({ data: req.body.data });
+      res.status(200).send(project);
+    } else {
+      res.status(400).send("Missing 'name', 'description', or 'githubUrl' fields.");
+    }
+  } catch (err) {
+    console.log(`[ERROR] ${err.message}`);
+    res.status(500).send({ error: true, message: err.message });
+  }
+});
+
+projectRoutes.route("/update").post(async (req, res) => {
+  try {
+    const count = await prisma.project.updateMany({
+      where: req.body.query,
+      data: req.body.update
+    });
+    res.status(200).send(count);
+  } catch (err) {
+    console.log(`[ERROR] ${err.message}`);
+    res.status(500).send({ error: true, message: err.message });
+  }
+});


### PR DESCRIPTION
### Problem Description
> Make routes to get and create/update projects. For the GET route, we should be able to filter by round, expo, and hackathon. We also need a route to change the round & expo number of multiple projects at a time. You can probably create a batch update endpoint for this.

### New Project Routes
* `[GET] /projects` → Uses query parameters to retrieve projects matching the passed-in criteria.
* `[POST] /projects` → Uses fields stored in the request body to create and push a new project to the database.
* `[POST] /projects/action/move` → Uses the `ids` array and other fields in the request body to update multiple projects.
* `[PATCH] /projects/:id` → Uses path parameter to find & update a project's content according to info in the request body.