### PR TITLE
Create hackathon and config routes

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -26,6 +26,8 @@ import { userRoutes } from "./routes/user";
 import { projectRoutes } from "./routes/project";
 import { categoryRoutes } from "./routes/categories";
 import { tableGroupRoutes } from "./routes/tablegroups";
+import { hackathonRoutes } from "./routes/hackathon";
+import { configRoutes } from "./routes/config";
 import { handleError } from "./utils/handleError";
 
 app.get("/status", (req, res) => {
@@ -37,6 +39,8 @@ app.use("/user", userRoutes);
 app.use("/projects", isAuthenticated, projectRoutes);
 app.use("/categories", isAuthenticated, categoryRoutes);
 app.use("/tablegroups", isAuthenticated, tableGroupRoutes);
+app.use("/hackathon", isAuthenticated, hackathonRoutes);
+app.use("/config", isAuthenticated, configRoutes);
 
 app.use(isAuthenticated, express.static(path.join(__dirname, "../../client/build")));
 app.get("*", isAuthenticated, (req, res) => {

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -4,7 +4,42 @@ import { asyncHandler } from "../utils/asyncHandler";
 
 export const configRoutes = express.Router();
 
-configRoutes.route("/currentRoundExpo").post(asyncHandler(async (req, res) => {}));
-configRoutes.route("/isJudgingOn").post(asyncHandler(async (req, res) => {}));
-configRoutes.route("/isProjectsPublished:").post(asyncHandler(async (req, res) => {}));
-configRoutes.route("/currentHackathonId").post(asyncHandler(async (req, res) => {}));
+configRoutes.route("/currentRoundExpo").post(
+  asyncHandler(async (req, res) => {
+    const update = await updateConfigFields(req.body, ["currentRound", "currentExpo"]);
+    res.status(201).json(update);
+  })
+);
+configRoutes.route("/isJudgingOn").post(
+  asyncHandler(async (req, res) => {
+    const update = await updateConfigFields(req.body, ["isJudgingOn"]);
+    res.status(201).json(update);
+  })
+);
+configRoutes.route("/isProjectsPublished").post(
+  asyncHandler(async (req, res) => {
+    const update = await updateConfigFields(req.body, ["isProjectsPublished"]);
+    res.status(201).json(update);
+  })
+);
+configRoutes.route("/currentHackathonId").post(
+  asyncHandler(async (req, res) => {
+    const update = await updateConfigFields(req.body, ["currentHackathonId"]);
+    res.status(201).json(update);
+  })
+);
+
+function updateConfigFields(data: any, fields: string[]) {
+  let filtered: any = {};
+
+  Object.keys(data).forEach(key => {
+    if (fields.includes(key)) {
+      filtered[key] = data[key];
+    }
+  });
+
+  return prisma.config.update({
+    where: { id: 1 },
+    data: filtered,
+  });
+}

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -7,25 +7,25 @@ export const configRoutes = express.Router();
 configRoutes.route("/currentRoundExpo").post(
   asyncHandler(async (req, res) => {
     const update = await updateConfigFields(req.body, ["currentRound", "currentExpo"]);
-    res.status(201).json(update);
+    res.status(200).json(update);
   })
 );
 configRoutes.route("/isJudgingOn").post(
   asyncHandler(async (req, res) => {
     const update = await updateConfigFields(req.body, ["isJudgingOn"]);
-    res.status(201).json(update);
+    res.status(200).json(update);
   })
 );
 configRoutes.route("/isProjectsPublished").post(
   asyncHandler(async (req, res) => {
     const update = await updateConfigFields(req.body, ["isProjectsPublished"]);
-    res.status(201).json(update);
+    res.status(200).json(update);
   })
 );
 configRoutes.route("/currentHackathonId").post(
   asyncHandler(async (req, res) => {
     const update = await updateConfigFields(req.body, ["currentHackathonId"]);
-    res.status(201).json(update);
+    res.status(200).json(update);
   })
 );
 

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -1,0 +1,10 @@
+import { prisma } from "../common";
+import express from "express";
+import { asyncHandler } from "../utils/asyncHandler";
+
+export const configRoutes = express.Router();
+
+configRoutes.route("/currentRoundExpo").post(asyncHandler(async (req, res) => {}));
+configRoutes.route("/isJudgingOn").post(asyncHandler(async (req, res) => {}));
+configRoutes.route("/isProjectsPublished:").post(asyncHandler(async (req, res) => {}));
+configRoutes.route("/currentHackathonId").post(asyncHandler(async (req, res) => {}));

--- a/server/src/routes/hackathon.ts
+++ b/server/src/routes/hackathon.ts
@@ -1,0 +1,31 @@
+import { prisma } from "../common";
+import express from "express";
+import { asyncHandler } from "../utils/asyncHandler";
+
+export const hackathonRoutes = express.Router();
+
+hackathonRoutes.route("/").get(
+  asyncHandler(async (req, res) => {
+    const hackathons = await prisma.hackathon.findMany({});
+    res.status(200).json(hackathons);
+  })
+);
+
+hackathonRoutes.route("/").post(
+  asyncHandler(async (req, res) => {
+    const created = await prisma.hackathon.create({
+      data: req.body,
+    });
+    res.status(201).json(created);
+  })
+);
+
+hackathonRoutes.route("/:id").patch(
+  asyncHandler(async (req, res) => {
+    const updated = await prisma.hackathon.update({
+      where: { id: parseInt(req.params.id) },
+      data: req.body,
+    });
+    res.status(200).json(updated);
+  })
+);


### PR DESCRIPTION
Hackathon Routes:
- Get hackathons
- Create hackthon
- Update hackathon by id

Config Routes
- Update current round and current expo number
- Update if judging is on
- Update if projects are published
- Update current hackathon


Closes #7 