### PR TITLE
Tablegroup tab admin

### DIFF
--- a/client/src/components/admin/AdminHome.tsx
+++ b/client/src/components/admin/AdminHome.tsx
@@ -6,6 +6,7 @@ import {
   SettingOutlined,
   ContainerOutlined,
   FolderOutlined,
+  GroupOutlined,
 } from "@ant-design/icons";
 
 import AdminContentList from "./AdminContentList";
@@ -19,7 +20,7 @@ const { Title, Text } = Typography;
 const { Sider, Content } = Layout;
 
 const AdminHome: React.FC = () => {
-  const paneKeys = ["config", "users", "categories", "categorygroups"];
+  const paneKeys = ["config", "users", "categories", "categorygroups", "tablegroups"];
   const { activePane } = useParams<any>();
   const history = useHistory();
 
@@ -118,6 +119,34 @@ const AdminHome: React.FC = () => {
         />
       );
       break;
+    case "tablegroups":
+      content = (
+        <AdminContentList
+          queryUrl="/tablegroups"
+          title="Table Groups"
+          sortData={data => data.concat().sort((a: any, b: any) => b.name - a.name)}
+          modal={CategoryFormModal}
+          searchFilterField="name"
+          renderItem={(item, index, openModal) => (
+            <List.Item style={{ backgroundColor: "white" }}>
+              <List.Item.Meta
+                title={item.name}
+                description={item.criterias
+                  .map(
+                    (criteria: any) =>
+                      `${criteria.name} [${criteria.minScore}-${criteria.maxScore}]`
+                  )
+                  .join(", ")}
+                avatar={<ContainerOutlined />}
+              />
+              <Button onClick={() => openModal(item)}>Edit</Button>
+            </List.Item>
+          )}
+          key="tablegroups"
+          listBordered
+        />
+      );
+      break;
   }
 
   const handleMenuClick = (event: any) => {
@@ -153,6 +182,9 @@ const AdminHome: React.FC = () => {
             </Menu.Item>
             <Menu.Item key="categorygroups" icon={<FolderOutlined />}>
               Category Groups
+            </Menu.Item>
+            <Menu.Item key="tablegroups" icon={<GroupOutlined />}>
+              Table Groups
             </Menu.Item>
           </Menu>
         </Sider>

--- a/client/src/components/admin/AdminHome.tsx
+++ b/client/src/components/admin/AdminHome.tsx
@@ -14,6 +14,7 @@ import UserFormModal from "./panes/users/UserFormModal";
 import ConfigEditPane from "./panes/config/ConfigEditPane";
 import CategoryGroupFormModal from "./panes/categorygroups/CategoryGroupFormModal";
 import CategoryFormModal from "./panes/categories/CategoryModal";
+import TableGroupsModal from "./panes/tableGroups/TableGroupsModal";
 import CategoryCard from "./panes/categories/CategoryCard";
 
 const { Title, Text } = Typography;
@@ -125,18 +126,13 @@ const AdminHome: React.FC = () => {
           queryUrl="/tablegroups"
           title="Table Groups"
           sortData={data => data.concat().sort((a: any, b: any) => b.name - a.name)}
-          modal={CategoryFormModal}
+          modal={TableGroupsModal}
           searchFilterField="name"
           renderItem={(item, index, openModal) => (
             <List.Item style={{ backgroundColor: "white" }}>
               <List.Item.Meta
                 title={item.name}
-                description={item.criterias
-                  .map(
-                    (criteria: any) =>
-                      `${criteria.name} [${criteria.minScore}-${criteria.maxScore}]`
-                  )
-                  .join(", ")}
+                description={`[${item.shortCode}] - ${item.color}`}
                 avatar={<ContainerOutlined />}
               />
               <Button onClick={() => openModal(item)}>Edit</Button>

--- a/client/src/components/admin/AdminHome.tsx
+++ b/client/src/components/admin/AdminHome.tsx
@@ -6,7 +6,7 @@ import {
   SettingOutlined,
   ContainerOutlined,
   FolderOutlined,
-  GroupOutlined,
+  TableOutlined,
 } from "@ant-design/icons";
 
 import AdminContentList from "./AdminContentList";
@@ -133,7 +133,7 @@ const AdminHome: React.FC = () => {
               <List.Item.Meta
                 title={item.name}
                 description={`[${item.shortCode}] - ${item.color}`}
-                avatar={<ContainerOutlined />}
+                avatar={<TableOutlined />}
               />
               <Button onClick={() => openModal(item)}>Edit</Button>
             </List.Item>
@@ -179,7 +179,7 @@ const AdminHome: React.FC = () => {
             <Menu.Item key="categorygroups" icon={<FolderOutlined />}>
               Category Groups
             </Menu.Item>
-            <Menu.Item key="tablegroups" icon={<GroupOutlined />}>
+            <Menu.Item key="tablegroups" icon={<TableOutlined />}>
               Table Groups
             </Menu.Item>
           </Menu>

--- a/client/src/components/admin/panes/tableGroups/TableGroupsModal.tsx
+++ b/client/src/components/admin/panes/tableGroups/TableGroupsModal.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect } from "react";
+import { Form, Input, message, Modal } from "antd";
+import axios from "axios";
+import useAxios from "axios-hooks";
+
+import { FORM_RULES, handleAxiosError } from "../../../../util/util";
+import { FormModalProps } from "../../../../util/FormModalProps";
+import ErrorDisplay from "../../../../displays/ErrorDisplay";
+import LoadingDisplay from "../../../../displays/LoadingDisplay";
+
+const TableGroupsModal: React.FC<FormModalProps> = props => {
+  const [{ data: tableGroupsData, loading: tableGroupsLoading, error: tableGroupsError }] =
+    useAxios("/categorygroups");
+
+  const [form] = Form.useForm();
+  useEffect(() => form.resetFields(), [form, props.modalState.initialValues]); // github.com/ant-design/ant-design/issues/22372
+
+  if (tableGroupsLoading) {
+    return <LoadingDisplay />;
+  }
+
+  if (tableGroupsError) {
+    return <ErrorDisplay error={tableGroupsError} />;
+  }
+
+  const onSubmit = async () => {
+    try {
+      const values = await form.validateFields();
+      const hide = message.loading("Loading...", 0);
+
+      console.log("Submission values:", values);
+
+      if (props.modalState.initialValues) {
+        axios
+          .patch(`/tablegroups/${props.modalState.initialValues.id}`, values)
+          .then(res => {
+            hide();
+            message.success("Table group successfully updated", 2);
+            props.setModalState({ visible: false, initialValues: null });
+            props.refetch();
+          })
+          .catch(err => {
+            hide();
+            handleAxiosError(err);
+          });
+      } else {
+        axios
+          .post(`/tablegroups`, values)
+          .then(res => {
+            hide();
+            message.success("Table group successfully created", 2);
+            props.setModalState({ visible: false, initialValues: null });
+            props.refetch();
+          })
+          .catch(err => {
+            hide();
+            handleAxiosError(err);
+          });
+      }
+    } catch (error) {
+      console.log("Validate Failed:", error);
+    }
+  };
+
+  return (
+    <Modal
+      visible={props.modalState.visible}
+      title={props.modalState.initialValues ? `Manage Config` : `Create Config`}
+      okText={props.modalState.initialValues ? "Update" : "Create"}
+      cancelText="Cancel"
+      onCancel={() => props.setModalState({ visible: false, initialValues: null })}
+      onOk={onSubmit}
+      bodyStyle={{ paddingBottom: 0 }}
+    >
+      <Form
+        form={form}
+        initialValues={props.modalState.initialValues}
+        layout="vertical"
+        autoComplete="off"
+      >
+        <Form.Item name="name" rules={[FORM_RULES.requiredRule]} label="Name">
+          <Input placeholder="Hardware Table" />
+        </Form.Item>
+
+        <Form.Item name="shortCode" rules={[FORM_RULES.requiredRule]} label="Short Code">
+          <Input placeholder="Hardware" />
+        </Form.Item>
+
+        <Form.Item name="color" rules={[FORM_RULES.requiredRule]} label="Color">
+          <Input placeholder="Blue" />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default TableGroupsModal;

--- a/client/src/components/admin/panes/tableGroups/TableGroupsModal.tsx
+++ b/client/src/components/admin/panes/tableGroups/TableGroupsModal.tsx
@@ -65,7 +65,7 @@ const TableGroupsModal: React.FC<FormModalProps> = props => {
   return (
     <Modal
       visible={props.modalState.visible}
-      title={props.modalState.initialValues ? `Manage Config` : `Create Config`}
+      title={props.modalState.initialValues ? `Manage Table Groups` : `Create Table Group`}
       okText={props.modalState.initialValues ? "Update" : "Create"}
       cancelText="Cancel"
       onCancel={() => props.setModalState({ visible: false, initialValues: null })}

--- a/server/src/routes/tablegroups.ts
+++ b/server/src/routes/tablegroups.ts
@@ -2,6 +2,7 @@ import express from "express";
 
 import { asyncHandler } from "../utils/asyncHandler";
 import { prisma } from "../common";
+import { getConfig } from "../utils/utils";
 import { isAdmin } from "../auth/auth";
 
 export const tableGroupRoutes = express.Router();
@@ -24,8 +25,13 @@ tableGroupRoutes.route("/").get(
 tableGroupRoutes.route("/").post(
   isAdmin,
   asyncHandler(async (req, res) => {
+    const config = await getConfig();
+
     const createdTableGroup = await prisma.tableGroup.create({
-      data: req.body,
+      data: {
+        ...req.body,
+        hackathonId: config.currentHackathonId,
+      },
     });
 
     res.status(201).json(createdTableGroup);


### PR DESCRIPTION
- Added tab for table groups in the Admin page
- Updated POST route for table groups to use current hackathonId
- Include modal for updating and adding table groups
<img width="1380" alt="Screen Shot 2022-02-10 at 10 43 59 PM" src="https://user-images.githubusercontent.com/22090159/153534587-40ca24c7-e5ce-4647-b62b-451137c20316.png">
<img width="516" alt="Screen Shot 2022-02-10 at 10 47 54 PM" src="https://user-images.githubusercontent.com/22090159/153534748-4d31ec5f-da80-4925-8998-0a4d432c5e0d.png">

