### PR TITLE
Update TableGroup Schema to include tableSize column

### DIFF
--- a/server/prisma/migrations/20220228022839_dev/migration.sql
+++ b/server/prisma/migrations/20220228022839_dev/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `tableSize` to the `table_group` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "table_group" ADD COLUMN     "tableSize" INTEGER NOT NULL;

--- a/server/prisma/migrations/20220228024308_dev/migration.sql
+++ b/server/prisma/migrations/20220228024308_dev/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `tableSize` on the `table_group` table. All the data in the column will be lost.
+  - Added the required column `tableCapacity` to the `table_group` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "table_group" DROP COLUMN "tableSize",
+ADD COLUMN     "tableCapacity" INTEGER NOT NULL;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -180,6 +180,7 @@ model TableGroup {
   color     String
   projects  Project[]
   hackathon Hackathon @relation(fields: [hackathonId], references: [id])
+  tableSize Int
 
   hackathonId Int
   @@map("table_group")

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -174,13 +174,13 @@ model Session {
 }
 
 model TableGroup {
-  id        Int       @id @default(autoincrement())
-  name      String
-  shortCode String
-  color     String
-  projects  Project[]
-  hackathon Hackathon @relation(fields: [hackathonId], references: [id])
-  tableSize Int
+  id            Int       @id @default(autoincrement())
+  name          String
+  shortCode     String
+  color         String
+  projects      Project[]
+  hackathon     Hackathon @relation(fields: [hackathonId], references: [id])
+  tableCapacity Int
 
   hackathonId Int
   @@map("table_group")


### PR DESCRIPTION
- Updated the TableGroup Schema to include tableCapacity column of type integer
- tableCapacity represents the total capacity a table can hold (ie: tableCapacity = 16 --> 16 teams can reside on that tablegroup)