### PR TITLE
Reload on Hexathon Change

### DIFF
--- a/src/components/admin/panes/config/ConfigEditPane.tsx
+++ b/src/components/admin/panes/config/ConfigEditPane.tsx
@@ -31,7 +31,6 @@ const ConfigEditPane: React.FC = props => {
 
   const onFinish = async (values: any) => {
     const hide = message.loading("Loading...", 0);
-    console.log(values);
     values.currentHexathon = values.hexathon;
     delete values.hexathon;
     const currHexObject = hexathonsData.find(

--- a/src/components/admin/panes/config/ConfigEditPane.tsx
+++ b/src/components/admin/panes/config/ConfigEditPane.tsx
@@ -31,16 +31,22 @@ const ConfigEditPane: React.FC = props => {
 
   const onFinish = async (values: any) => {
     const hide = message.loading("Loading...", 0);
+    console.log(values);
     values.currentHexathon = values.hexathon;
     delete values.hexathon;
-    const currHexObject = hexathonsData.find((hexathon: any) => hexathon.id === values.currentHexathon);
-    console.log('currHexObject: ', currHexObject)
-    setCurrentHexathon(currHexObject);
+    const currHexObject = hexathonsData.find(
+      (hexathon: any) => hexathon.id === values.currentHexathon
+    );
+    console.log("currHexObject: ", currHexObject);
+    setCurrentHexathon(() => ({ ...currHexObject }));
     axios
       .post(apiUrl(Service.EXPO, "/config"), values)
       .then(res => {
         hide();
         message.success("Config successfully updated", 2);
+        setTimeout(() => {
+          window.location.reload();
+        }, 500);
       })
       .catch(err => {
         hide();

--- a/src/components/admin/panes/config/ConfigEditPane.tsx
+++ b/src/components/admin/panes/config/ConfigEditPane.tsx
@@ -42,10 +42,7 @@ const ConfigEditPane: React.FC = props => {
       .post(apiUrl(Service.EXPO, "/config"), values)
       .then(res => {
         hide();
-        message.success("Config successfully updated", 2);
-        setTimeout(() => {
-          window.location.reload();
-        }, 500);
+        message.success("Config successfully updated", 2, () => window.location.reload());
       })
       .catch(err => {
         hide();


### PR DESCRIPTION
- Reloads the window upon form submission

I found that the `currentHexathon` state wasn't being updated in `ConfigEditPane.tsx`, which caused the app context to keep using the old hexathon instead. Spend some time trying to address this without having to reload the whole app but found no luck, so if there's a better alternative, feel free to suggest here.