### PR TITLE
Update admin panel for initial value updates and request cleanup

### DIFF
--- a/src/components/admin/AdminContentList.tsx
+++ b/src/components/admin/AdminContentList.tsx
@@ -1,17 +1,5 @@
 import React, { useState } from "react";
-import {
-  Button,
-  List,
-  Typography,
-  Input,
-  Col,
-  Select,
-  Tag,
-  Dropdown,
-  Checkbox,
-  Pagination,
-  PaginationProps,
-} from "antd";
+import { Button, List, Typography, Input, Select } from "antd";
 import { ListGridType } from "antd/lib/list";
 import useAxios from "axios-hooks";
 import { apiUrl, Service } from "@hex-labs/core";
@@ -48,7 +36,6 @@ const AdminContentList: React.FC<Props> = props => {
     initialValues: null,
   } as ModalState);
   const [searchText, setSearchText] = useState("");
-  const [userRole, setUserRole] = useState<any>(undefined);
   const [isJudging, setIsJudging] = useState<any>(undefined);
 
   const [{ loading, data, error }, refetch] = useAxios({
@@ -88,7 +75,7 @@ const AdminContentList: React.FC<Props> = props => {
   ];
 
   updatedData = isJudging
-    ? updatedData.filter((user: User) => user.isJudging.toString() == isJudging)
+    ? updatedData.filter((user: User) => user.isJudging.toString() === isJudging)
     : updatedData;
 
   const Modal = props.modal;

--- a/src/components/admin/AdminHome.tsx
+++ b/src/components/admin/AdminHome.tsx
@@ -15,7 +15,6 @@ import ConfigEditPane from "./panes/config/ConfigEditPane";
 import CategoryGroupFormModal from "./panes/categorygroups/CategoryGroupFormModal";
 import CategoryFormModal from "./panes/categories/CategoryModal";
 import TableGroupsModal from "./panes/tableGroups/TableGroupsModal";
-import CategoryCard from "./panes/categories/CategoryCard";
 
 const { Title, Text } = Typography;
 const { Sider, Content } = Layout;

--- a/src/components/admin/panes/categories/CategoryModal.tsx
+++ b/src/components/admin/panes/categories/CategoryModal.tsx
@@ -13,27 +13,27 @@ const { TextArea } = Input;
 
 const CategoryFormModal: React.FC<FormModalProps> = props => {
   const [form] = Form.useForm();
-  useEffect(() => form.resetFields(), [form, props.modalState.initialValues]); // github.com/ant-design/ant-design/issues/22372
-  const onDelete = async () => {
-    try {
-      if (props.modalState.initialValues) {
-        axios
-          .delete(apiUrl(Service.EXPO, `/categories/${props.modalState.initialValues.id}`))
-          .then(res => {
-            message.success("Category successfully deleted", 2);
-            props.setModalState({ visible: false, initialValues: null });
-            props.refetch();
-          })
-          .catch(err => {
-            handleAxiosError(err);
-          });
-      } else {
-        message.error("Category group could not be deleted");
-      }
-    } catch (error) {
-      console.log("Validate Failed:", error);
+  useEffect(() => {
+    if (props.modalState.initialValues) {
+      form.setFieldsValue(props.modalState.initialValues);
+    } else {
+      form.resetFields();
     }
+  }, [form, props.modalState.initialValues]); // github.com/ant-design/ant-design/issues/22372
+
+  const onDelete = async () => {
+    axios
+      .delete(apiUrl(Service.EXPO, `/categories/${props.modalState.initialValues.id}`))
+      .then(res => {
+        message.success("Category successfully deleted", 2);
+        props.setModalState({ visible: false, initialValues: null });
+        props.refetch();
+      })
+      .catch(err => {
+        handleAxiosError(err);
+      });
   };
+
   const onSubmit = async () => {
     try {
       const values = await form.validateFields();
@@ -81,16 +81,18 @@ const CategoryFormModal: React.FC<FormModalProps> = props => {
       onOk={onSubmit}
       bodyStyle={{ paddingBottom: 0 }}
       footer={[
-        <Popconfirm
-          title="Are you sure you want to delete this category?"
-          onConfirm={onDelete}
-          okText="Yes"
-          cancelText="No"
-        >
-          <Button danger style={{ float: "left" }}>
-            Delete
-          </Button>
-        </Popconfirm>,
+        props.modalState.initialValues && (
+          <Popconfirm
+            title="Are you sure you want to delete this category?"
+            onConfirm={onDelete}
+            okText="Yes"
+            cancelText="No"
+          >
+            <Button danger style={{ float: "left" }}>
+              Delete
+            </Button>
+          </Popconfirm>
+        ),
         <Button
           key="2"
           onClick={() => props.setModalState({ visible: false, initialValues: null })}
@@ -102,12 +104,7 @@ const CategoryFormModal: React.FC<FormModalProps> = props => {
         </Button>,
       ]}
     >
-      <Form
-        form={form}
-        initialValues={props.modalState.initialValues}
-        layout="vertical"
-        autoComplete="off"
-      >
+      <Form form={form} layout="vertical" autoComplete="off">
         <Form.Item name="name" rules={[FORM_RULES.requiredRule]} label="Name">
           <Input />
         </Form.Item>

--- a/src/components/admin/panes/categorygroups/CategoryGroupFormModal.tsx
+++ b/src/components/admin/panes/categorygroups/CategoryGroupFormModal.tsx
@@ -27,7 +27,17 @@ const CategoryGroupFormModal: React.FC<FormModalProps> = props => {
   });
 
   const [form] = Form.useForm();
-  useEffect(() => form.resetFields(), [form, props.modalState.initialValues]); // github.com/ant-design/ant-design/issues/22372
+  useEffect(() => {
+    if (props.modalState.initialValues) {
+      form.setFieldsValue({
+        ...props.modalState.initialValues,
+        categories: props.modalState.initialValues?.categories.map((category: any) => category.id),
+        users: props.modalState.initialValues?.users.map((user: any) => user.id),
+      });
+    } else {
+      form.resetFields();
+    }
+  }, [form, props.modalState.initialValues]); // github.com/ant-design/ant-design/issues/22372
 
   if (userLoading || categoriesLoading) {
     return <LoadingDisplay />;
@@ -36,26 +46,20 @@ const CategoryGroupFormModal: React.FC<FormModalProps> = props => {
   if (userError || categoriesError) {
     return <ErrorDisplay error={userError} />;
   }
+
   const onDelete = async () => {
-    try {
-      if (props.modalState.initialValues) {
-        axios
-          .delete(apiUrl(Service.EXPO, `/categorygroups/${props.modalState.initialValues.id}`))
-          .then(res => {
-            message.success("Category group successfully deleted", 2);
-            props.setModalState({ visible: false, initialValues: null });
-            props.refetch();
-          })
-          .catch(err => {
-            handleAxiosError(err);
-          });
-      } else {
-        message.error("Category group could not be deleted");
-      }
-    } catch (error) {
-      console.log("Validate Failed:", error);
-    }
+    axios
+      .delete(apiUrl(Service.EXPO, `/categorygroups/${props.modalState.initialValues.id}`))
+      .then(res => {
+        message.success("Category group successfully deleted", 2);
+        props.setModalState({ visible: false, initialValues: null });
+        props.refetch();
+      })
+      .catch(err => {
+        handleAxiosError(err);
+      });
   };
+
   const onSubmit = async () => {
     try {
       const values = await form.validateFields();
@@ -118,17 +122,18 @@ const CategoryGroupFormModal: React.FC<FormModalProps> = props => {
       onCancel={() => props.setModalState({ visible: false, initialValues: null })}
       cancelText="Cancel"
       footer={[
-        <Popconfirm
-          title="Are you sure you want to delete this category group?"
-          onConfirm={onDelete}
-          okText="Yes"
-          cancelText="No"
-        >
-          <Button danger style={{ float: "left" }}>
-            Delete
-          </Button>
-        </Popconfirm>,
-
+        props.modalState.initialValues && (
+          <Popconfirm
+            title="Are you sure you want to delete this category group?"
+            onConfirm={onDelete}
+            okText="Yes"
+            cancelText="No"
+          >
+            <Button danger style={{ float: "left" }}>
+              Delete
+            </Button>
+          </Popconfirm>
+        ),
         <Button
           key="2"
           onClick={() => props.setModalState({ visible: false, initialValues: null })}
@@ -142,21 +147,10 @@ const CategoryGroupFormModal: React.FC<FormModalProps> = props => {
       bodyStyle={{ paddingBottom: 0 }}
     >
       <Form form={form} layout="vertical" autoComplete="off">
-        <Form.Item
-          name="name"
-          rules={[FORM_RULES.requiredRule]}
-          label="Name"
-          initialValue={props.modalState.initialValues?.name}
-        >
+        <Form.Item name="name" rules={[FORM_RULES.requiredRule]} label="Name">
           <Input />
         </Form.Item>
-        <Form.Item
-          name="categories"
-          label="Categories"
-          initialValue={props.modalState.initialValues?.categories.map(
-            (category: any) => category.id
-          )}
-        >
+        <Form.Item name="categories" label="Categories">
           <Select
             mode="multiple"
             options={categoryOptions}
@@ -165,11 +159,7 @@ const CategoryGroupFormModal: React.FC<FormModalProps> = props => {
             allowClear
           />
         </Form.Item>
-        <Form.Item
-          name="users"
-          label="Users"
-          initialValue={props.modalState.initialValues?.users.map((user: any) => user.id)}
-        >
+        <Form.Item name="users" label="Users">
           <Select
             mode="multiple"
             options={userOptions}

--- a/src/components/admin/panes/tableGroups/TableGroupsModal.tsx
+++ b/src/components/admin/panes/tableGroups/TableGroupsModal.tsx
@@ -14,16 +14,7 @@ const TableGroupsModal: React.FC<FormModalProps> = props => {
   const CurrentHexathonContext = useCurrentHexathon();
   const { currentHexathon } = CurrentHexathonContext;
 
-  const [{ loading: projectsLoading, data: projectsData, error: projectsError }, refetchProjects] =
-    useAxios({
-      method: "GET",
-      url: apiUrl(Service.EXPO, "/projects"),
-      params: {
-        hexathon: currentHexathon.id,
-      },
-    });
-
-  const [{ loading: tableGroupsLoading, error: tableGroupsError }, refetchTableGroups] = useAxios({
+  const [{ loading: tableGroupsLoading, error: tableGroupsError }] = useAxios({
     method: "GET",
     url: apiUrl(Service.EXPO, "/tablegroups"),
     params: {
@@ -32,49 +23,33 @@ const TableGroupsModal: React.FC<FormModalProps> = props => {
   });
 
   const [form] = Form.useForm();
-  useEffect(() => form.resetFields(), [form, props.modalState.initialValues]); // github.com/ant-design/ant-design/issues/22372
+  useEffect(() => {
+    if (props.modalState.initialValues) {
+      form.setFieldsValue(props.modalState.initialValues);
+    } else {
+      form.resetFields();
+    }
+  }, [form, props.modalState.initialValues]); // github.com/ant-design/ant-design/issues/22372
 
-  if (tableGroupsLoading || projectsLoading) {
+  if (tableGroupsLoading) {
     return <LoadingDisplay />;
   }
 
   if (tableGroupsError) {
     return <ErrorDisplay error={tableGroupsError} />;
   }
-  if (projectsError) {
-    return <ErrorDisplay error={projectsError} />;
-  }
 
   const onDelete = async () => {
-    if (
-      projectsData.some(
-        (e: { tableGroupId: number }) => e.tableGroupId === props.modalState.initialValues.id
-      )
-    ) {
-      /* vendors contains the element we're looking for */
-      message.error(
-        "Table group could not be deleted. Change all projects assigned to this table group first."
-      );
-      return;
-    }
-    try {
-      if (props.modalState.initialValues) {
-        axios
-          .delete(apiUrl(Service.EXPO, `/tablegroups/${props.modalState.initialValues.id}`))
-          .then(res => {
-            message.success("Category group successfully deleted", 2);
-            props.setModalState({ visible: false, initialValues: null });
-            props.refetch();
-          })
-          .catch(err => {
-            handleAxiosError(err);
-          });
-      } else {
-        message.error("Table group could not be deleted");
-      }
-    } catch (error) {
-      console.log("Validate Failed:", error);
-    }
+    axios
+      .delete(apiUrl(Service.EXPO, `/tablegroups/${props.modalState.initialValues.id}`))
+      .then(res => {
+        message.success("Category group successfully deleted", 2);
+        props.setModalState({ visible: false, initialValues: null });
+        props.refetch();
+      })
+      .catch(err => {
+        handleAxiosError(err);
+      });
   };
 
   const onSubmit = async () => {
@@ -122,16 +97,18 @@ const TableGroupsModal: React.FC<FormModalProps> = props => {
       onCancel={() => props.setModalState({ visible: false, initialValues: null })}
       cancelText="Cancel"
       footer={[
-        <Popconfirm
-          title="Are you sure you want to delete this table group?"
-          onConfirm={onDelete}
-          okText="Yes"
-          cancelText="No"
-        >
-          <Button danger style={{ float: "left" }}>
-            Delete
-          </Button>
-        </Popconfirm>,
+        props.modalState.initialValues && (
+          <Popconfirm
+            title="Are you sure you want to delete this table group?"
+            onConfirm={onDelete}
+            okText="Yes"
+            cancelText="No"
+          >
+            <Button danger style={{ float: "left" }}>
+              Delete
+            </Button>
+          </Popconfirm>
+        ),
         <Button
           key="2"
           onClick={() => props.setModalState({ visible: false, initialValues: null })}
@@ -144,33 +121,16 @@ const TableGroupsModal: React.FC<FormModalProps> = props => {
       ]}
       bodyStyle={{ paddingBottom: 0 }}
     >
-      {/* <Modal
-      visible={props.modalState.visible}
-      title={props.modalState.initialValues ? `Manage Table Groups` : `Create Table Group`}
-      okText={props.modalState.initialValues ? "Update" : "Create"}
-      cancelText="Cancel"
-      onCancel={() => props.setModalState({ visible: false, initialValues: null })}
-      onOk={onSubmit}
-      bodyStyle={{ paddingBottom: 0 }}
-    > */}
-      <Form
-        form={form}
-        initialValues={props.modalState.initialValues}
-        layout="vertical"
-        autoComplete="off"
-      >
+      <Form form={form} layout="vertical" autoComplete="off">
         <Form.Item name="name" rules={[FORM_RULES.requiredRule]} label="Name">
-          <Input placeholder="Hardware Table" />
+          <Input placeholder="Klaus Atrium" />
         </Form.Item>
-
         <Form.Item name="shortCode" rules={[FORM_RULES.requiredRule]} label="Short Code">
-          <Input placeholder="Hardware" />
+          <Input placeholder="ATRIUM" />
         </Form.Item>
-
         <Form.Item name="tableCapacity" rules={[FORM_RULES.requiredRule]} label="Table Capacity">
-          <InputNumber placeholder="Table Capacity" />
+          <InputNumber placeholder="100" />
         </Form.Item>
-
         <Form.Item name="color" rules={[FORM_RULES.requiredRule]} label="Color">
           <Input placeholder="Blue" />
         </Form.Item>

--- a/src/components/admin/panes/users/UserFormModal.tsx
+++ b/src/components/admin/panes/users/UserFormModal.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from "react";
-import { Select, Form, Input, message, Modal, Radio, Switch, Tooltip, Typography } from "antd";
-import { QuestionCircleOutlined } from "@ant-design/icons/lib";
+import { Select, Form, Input, message, Modal, Switch, Typography } from "antd";
 import axios from "axios";
 import useAxios from "axios-hooks";
 import { apiUrl, Service } from "@hex-labs/core";
@@ -8,13 +7,11 @@ import { apiUrl, Service } from "@hex-labs/core";
 import { FORM_RULES } from "../../../../util/util";
 import { FormModalProps } from "../../../../util/FormModalProps";
 import QuestionIconLabel from "../../../../util/QuestionIconLabel";
-import { CategoryGroup } from "../../../../types/CategoryGroup";
 import ErrorDisplay from "../../../../displays/ErrorDisplay";
 import LoadingDisplay from "../../../../displays/LoadingDisplay";
 import { useCurrentHexathon } from "../../../../contexts/CurrentHexathonContext";
 
 const { Text } = Typography;
-const { Option } = Select;
 
 const UserFormModal: React.FC<FormModalProps> = props => {
   const CurrentHexathonContext = useCurrentHexathon();
@@ -95,6 +92,12 @@ const UserFormModal: React.FC<FormModalProps> = props => {
             options={categoryGroupsOptions}
             loading={categoryGroupsLoading}
             allowClear
+            onChange={(value: any) => {
+              // Will remove categoryGroup from user
+              if (value === undefined) {
+                form.setFieldsValue({ categoryGroupId: null });
+              }
+            }}
           />
         </Form.Item>
         <Form.Item
@@ -124,11 +127,6 @@ const UserFormModal: React.FC<FormModalProps> = props => {
         <Text strong>Email</Text>
         <br />
         <Text>{props.modalState.initialValues?.email || "Not Set"}</Text>
-        <br />
-        <br />
-        <Text strong>Ground Truth Id</Text>
-        <br />
-        <Text>{props.modalState.initialValues?.uuid || "Not Set"}</Text>
         <br />
         <br />
       </Form>


### PR DESCRIPTION
- Update admin routes initialValues so that modal will update. Right now, if you click on a row and then click to create one, the populated fields don't clear
- Cleaned up the requests
- Moved the table group deletion error to the backend for better protection
- Removed unneeded imports
- Only show "Delete" button on editing modals