### PR TITLE
changed Users page to only show category groups that a part of the hexathon

### DIFF
--- a/src/components/admin/AdminContentList.tsx
+++ b/src/components/admin/AdminContentList.tsx
@@ -79,6 +79,17 @@ const AdminContentList: React.FC<Props> = props => {
     ? updatedData.filter((user: User) => user.isJudging.toString() === isJudging)
     : updatedData;
 
+  if (props.queryUrl === "/users") {
+    for (const user of updatedData) {
+      console.log(user);
+      if (user.categoryGroup?.hexathon.toString() !== currentHexathon.id) {
+        user.newCategoryGroupName = "N/A";
+      } else {
+        user.newCategoryGroupName = user.categoryGroup.name;
+      }
+    }
+  }
+
   const Modal = props.modal;
 
   return (

--- a/src/components/admin/AdminHome.tsx
+++ b/src/components/admin/AdminHome.tsx
@@ -52,7 +52,7 @@ const AdminHome: React.FC = () => {
                 description={
                   <div>
                     <Text style={{ display: "block" }}>
-                      Category Group: {item.categoryGroup?.name || "N/A"}
+                      Category Group: {item.newCategoryGroupName}
                     </Text>
                     <div>
                       <Tag>{item.role}</Tag>


### PR DESCRIPTION
changed Users page in Admin to output the user's category group if that category group exists in the hexathon, otherwise it outputs "N/A" for that user's category group
