### PR TITLE
Added additional skip project button

### DIFF
--- a/src/components/judging/JudgingCardsContainer.tsx
+++ b/src/components/judging/JudgingCardsContainer.tsx
@@ -141,7 +141,7 @@ const JudgingCardsContainer: React.FC<Props> = props => {
           okText="Yes"
           cancelText="No"
         >
-          <Button>This Project Is Not Here</Button>
+          <Button style={{ marginRight: "10px" }}>This Project Is Not Here</Button>
         </Popconfirm>
         <Popconfirm
           placement="right"

--- a/src/components/judging/JudgingCardsContainer.tsx
+++ b/src/components/judging/JudgingCardsContainer.tsx
@@ -143,6 +143,15 @@ const JudgingCardsContainer: React.FC<Props> = props => {
         >
           <Button>This Project Is Not Here</Button>
         </Popconfirm>
+        <Popconfirm
+          placement="right"
+          title="Are you sure you want to skip this project?"
+          onConfirm={onSkip}
+          okText="Yes"
+          cancelText="No"
+        >
+          <Button>Skip Project</Button>
+        </Popconfirm>
       </div>
     </>
   );


### PR DESCRIPTION
Current button layout appearance:
![image](https://github.com/HackGT/timber/assets/31454324/dd37b465-a7f5-408c-9530-51353f189343)
Works the same as the "project is not here" button and is viewable in the list of skipped projects.