### PR TITLE
Added Judging timer and popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "antd": "^4.16.13",
     "axios": "^1.1.2",
     "axios-hooks": "^2.7.0",
+    "chakra-ui": "^0.3.9",
     "craco-less": "^2.0.0",
     "firebase": "^9.12.0",
     "framer-motion": "^7.5.3",

--- a/src/components/judging/JudgingHome.tsx
+++ b/src/components/judging/JudgingHome.tsx
@@ -1,7 +1,7 @@
 import useAxios from "axios-hooks";
 import React from "react";
 import { apiUrl, Service } from "@hex-labs/core";
-import { useDisclosure, Box, Button, Heading, Link } from "@chakra-ui/react";
+import { useDisclosure, Box, Button, Heading, Link, HStack } from "@chakra-ui/react";
 
 import ErrorDisplay from "../../displays/ErrorDisplay";
 import LoadingDisplay from "../../displays/LoadingDisplay";
@@ -11,6 +11,7 @@ import { Assignment } from "../../types/Assignment";
 import { Project } from "../../types/Project";
 import { useCurrentHexathon } from "../../contexts/CurrentHexathonContext";
 import { SkippedModal } from "./SkippedModal";
+import JudgingTimer from "./JudgingTimer";
 
 interface Props {
   user: User;
@@ -145,12 +146,16 @@ const JudgingHome: React.FC<Props> = props => {
     <>
       <Box display="flex" justifyContent="space-between">
         <Box>
-          <Heading
-            as="h1"
-            style={{ paddingBottom: "15px", fontSize: "35px", fontWeight: "normal" }}
-          >
-            Project Name: {data.name}
-          </Heading>
+          <HStack spacing={1}>
+            <Heading
+              as="h1"
+              style={{ paddingBottom: "15px", fontSize: "35px", fontWeight: "normal" }}
+            >
+              Project Name: {data.name}
+            </Heading>
+            <JudgingTimer />
+          </HStack>
+
           <Heading
             as="h3"
             style={{ paddingBottom: "10px", fontSize: "20px", fontWeight: "normal" }}

--- a/src/components/judging/JudgingTimer.tsx
+++ b/src/components/judging/JudgingTimer.tsx
@@ -1,0 +1,82 @@
+import { HeaderItem } from "@hex-labs/core";
+import { Text, Box, Modal, ModalOverlay, ModalContent, ModalHeader, ModalFooter, ModalBody, ModalCloseButton, Button} from "@chakra-ui/react";
+import React, {useEffect, useState} from "react";
+
+const formatTime = (time: number): string => {
+  const minutes = Math.floor(time / 60);
+  const seconds = time % 60;
+
+  const formattedMinutes = minutes < 10 ? `0${minutes}` : `${minutes}`;
+  const formattedSeconds = seconds < 10 ? `0${seconds}` : `${seconds}`;
+
+  return `${formattedMinutes}:${formattedSeconds}`;
+};
+
+const JudgingTimer: React.FC<any> = () => {
+  const [time, setTime] = useState(0);
+  const [isPopupOpen, setPopupOpen] = useState(false);
+
+  const countdownTimerStyle = {
+    fontFamily: "monospace",
+    padding: "5px",
+    border: "2px solid #333",
+    borderRadius: "5px",
+    backgroundColor: "#f0f0f0",
+  };
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setTime((prevTime: number) => {
+        // Show popup when the timer hits 4 minutes (240 seconds)
+        if (prevTime === 240) {
+          setPopupOpen(true);
+          clearInterval(intervalId);
+        }
+        return prevTime + 1;
+      });
+    }, 1000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  const handleClosePopup = () => {
+    setPopupOpen(false);
+    // Resume the timer
+    const resumeIntervalId = setInterval(() => {
+      setTime((prevTime) => prevTime + 1);
+    }, 1000);
+
+  };
+
+  return (
+    <HeaderItem>
+      <Box display="block">
+        <Text textAlign="right">
+          <span id="current-time" style={countdownTimerStyle}>
+            {formatTime(time)}
+          </span>
+        </Text>
+      </Box>
+
+      <Modal isOpen={isPopupOpen} onClose={handleClosePopup}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Please Wrap Up Judging</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Text>The timer has reached 4 minutes</Text>
+          </ModalBody>
+          <ModalFooter>
+            <Button colorScheme="blue" onClick={handleClosePopup}>
+              Close
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </HeaderItem>
+  );
+};
+
+export default JudgingTimer;


### PR DESCRIPTION
The judging timer looks like this:
![image](https://github.com/HackGT/timber/assets/31454324/b47b5ee9-6d52-4d3c-a970-4b376eccd42e)

and when the timer hits 4 minutes, the timer pauses and triggers a popup reminding judges about the time:
![image](https://github.com/HackGT/timber/assets/31454324/57d15cb9-80e7-4648-b8c6-52fa7b58f11d)

The timer resets when a project score is submitted or when it is skipped so that every new project that the judges see will start at 0 minutes and 0 seconds.